### PR TITLE
Fix require syntax

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ var requireIndex = require("requireindex");
 
 
 // import all rules in lib/rules
-module.exports.rules = requireIndex("./rules");
+module.exports.rules = requireIndex(__dirname + "/rules");
 
 
 


### PR DESCRIPTION
This is actually a bug in the Yoeman generator: https://github.com/eslint/generator-eslint/pull/15
